### PR TITLE
small imporovement for tests and linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,10 @@
       "^.+\\.tsx?$": "ts-jest"
     },
     "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "/dist/"
+    ],
     "moduleFileExtensions": [
       "ts",
       "tsx",

--- a/tslint.json
+++ b/tslint.json
@@ -47,7 +47,11 @@
         "function-constructor": true,
         "increment-decrement": false,
         "interface-over-type-literal": false,
-        "import-blacklist": true,
+        "import-blacklist": [
+            true, 
+            "sequelize/types", 
+            {"@nestjs/common": ["Logger"]}
+        ],
         "import-spacing": true,
         "indent": [
             true,


### PR DESCRIPTION
* don't run tests in `/dist` (maybe we should just not build tests?)
* don't allow importing from `sequelize/types` (results in wrong import token for SequelizeModule)
* don't allow importing `Logger` from `@nestjs/common` (duplicate to our `@erento/nestjs-common`)